### PR TITLE
feat: improve reader derivation rules for values and directions

### DIFF
--- a/src/om-file-reader.ts
+++ b/src/om-file-reader.ts
@@ -94,7 +94,6 @@ export class OMapsFileReader {
 			if (typeof rule.pattern === 'string') {
 				return variable.includes(rule.pattern);
 			} else {
-				console.log('Checking pattern:', rule.pattern);
 				return rule.pattern.test(variable);
 			}
 		});
@@ -180,10 +179,8 @@ export class OMapsFileReader {
 		const derivationRule = this.findDerivationRule(variable);
 
 		if (derivationRule) {
-			console.log('Derivation rule found:', derivationRule);
 			return this.readWithDerivationRule(variable, derivationRule, ranges);
 		} else {
-			console.log('No derivation rule found');
 			return this.readSimpleVariable(variable, ranges);
 		}
 	}


### PR DESCRIPTION
### Summary

- improves how derivation rules for values and directions are defined in a more generic way
- fixes detection for `wave_height` and `wave_direction` if part of a variable such as `tertiary_swell_wave_height`

### Notes

- theoretically this could be extended to have different rules to derive from one, two, three, ... variables
- we could also have special names for the derived variables, e.g. `wind_speed_and_direction_500hPa` and use that to derive from u and v components
- derivation rules could be mode user-definable