### PR TITLE
feat: Add combined variable example

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ The repository contains an `examples` directory with ready-to-run demos:
 - `examples/precipitation.html` – displays precipitation using a similar setup.
 - `examples/wind.html` – displays wind values with directional arrows.
 - `examples/custom-colorscale.html` – shows how to use your own color definition.
+- `examples/combined-variables.html` – shows multiple data sources on the same map.
 
 Run the examples by opening the corresponding `.html` file in a browser.
 

--- a/examples/combined-variables.html
+++ b/examples/combined-variables.html
@@ -1,0 +1,83 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<title>Open-Meteo Mapbox Layer - Temperature Example</title>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<link rel="stylesheet" href="https://unpkg.com/maplibre-gl@5.13.0/dist/maplibre-gl.css" />
+		<script src="https://unpkg.com/maplibre-gl@5.13.0/dist/maplibre-gl.js"></script>
+		<!-- x-release-please-start-version -->
+		<script src="https://unpkg.com/@openmeteo/mapbox-layer@0.0.8/dist/index.js"></script>
+		<!-- x-release-please-end -->
+		<!-- Local development -->
+		<!--<script src="../dist/index.js"></script>-->
+		<style>
+			html,
+			body,
+			#map {
+				margin: 0;
+				padding: 0;
+				height: 100%;
+			}
+		</style>
+	</head>
+	<body>
+		<div id="map"></div>
+		<script>
+			maplibregl.addProtocol('om', OpenMeteoMapboxLayer.omProtocol);
+
+			const map = new maplibregl.Map({
+				container: 'map',
+				style: {
+					version: 8,
+					sources: {
+						osm: {
+							type: 'raster',
+							tiles: ['https://a.tile.openstreetmap.org/{z}/{x}/{y}.png'],
+							tileSize: 256,
+							attribution: '&copy; OpenStreetMap Contributors'
+						}
+					},
+					layers: [
+						{
+							id: 'osm',
+							type: 'raster',
+							source: 'osm'
+						}
+					]
+				},
+				hash: true
+			});
+
+			const omUrl = `https://map-tiles.open-meteo.com/data_spatial/dwd_icon/latest.json?time_step=current_time_1H`;
+			const omCloudCoverUrl = omUrl + `&variable=cloud_cover`;
+			const omPrecipitationUrl = omUrl + `&variable=precipitation`;
+
+			map.on('load', () => {
+				map.addSource('omCloudCoverSource', {
+					url: 'om://' + omCloudCoverUrl,
+					type: 'raster',
+					tileSize: 256,
+					maxzoom: 12
+				});
+				map.addLayer({
+					id: 'omCloudCoverLayer',
+					type: 'raster',
+					source: 'omCloudCoverSource'
+				});
+
+				map.addSource('omPrecipitationSource', {
+					url: 'om://' + omPrecipitationUrl,
+					type: 'raster',
+					tileSize: 256,
+					maxzoom: 12
+				});
+				map.addLayer({
+					id: 'omPrecipitationLayer',
+					type: 'raster',
+					source: 'omPrecipitationSource'
+				});
+			});
+		</script>
+	</body>
+</html>


### PR DESCRIPTION
### Summary

- Adds a new example that showcases the use of multiple sources, for example when displaying multiple variables like `cloud_cover` & `precipitation` 