### PR TITLE
fix: remove assertion for valid om urls

### DIFF
--- a/src/om-protocol.ts
+++ b/src/om-protocol.ts
@@ -2,7 +2,7 @@ import { type GetResourceResponse, type RequestParameters } from 'maplibre-gl';
 
 import { clipBounds } from './utils/math';
 import { defaultResolveRequest, parseRequest } from './utils/parse-request';
-import { assertOmUrlValid, parseMetaJson } from './utils/parse-url';
+import { parseMetaJson } from './utils/parse-url';
 import { COLOR_SCALES_WITH_ALIASES as defaultColorScales } from './utils/styling';
 
 import { domainOptions as defaultDomainOptions } from './domains';
@@ -81,7 +81,6 @@ const normalizeUrl = async (url: string): Promise<string> => {
 	if (url.includes('.json')) {
 		normalized = await parseMetaJson(normalized);
 	}
-	assertOmUrlValid(normalized);
 	return normalized;
 };
 

--- a/src/tests/parse.test.ts
+++ b/src/tests/parse.test.ts
@@ -1,5 +1,5 @@
 import { pad } from '../utils';
-import { assertOmUrlValid, parseMetaJson, parseUrlComponents } from '../utils/parse-url';
+import { parseMetaJson, parseUrlComponents } from '../utils/parse-url';
 import { describe, expect, it } from 'vitest';
 
 describe('URL Parsing', () => {
@@ -23,33 +23,6 @@ describe('URL Parsing', () => {
 			const parsedUrl = await parseMetaJson(url);
 
 			expect(parsedUrl).not.toContain('in-progress');
-			assertOmUrlValid(parsedUrl);
-		});
-	});
-
-	describe('assertOmUrlValid', () => {
-		it('accepts valid OM URLs', () => {
-			expect(
-				assertOmUrlValid(
-					'https://map-tiles.open-meteo.com/data_spatial/dwd_icon/2025/11/17/0600Z/2025-11-17T1300.om'
-				)
-			).toBe(true);
-		});
-
-		it('rejects invalid domain', () => {
-			expect(() =>
-				assertOmUrlValid(
-					'https://map-tiles.open-meteo.com/data_spatial/not_a_valid_domain/2025/11/17/0600Z/2025-11-17T1300.om'
-				)
-			).toThrowError('Invalid Domain');
-		});
-
-		it('rejects model run too far in the past', () => {
-			expect(() =>
-				assertOmUrlValid(
-					'https://map-tiles.open-meteo.com/data_spatial/dwd_icon/2024/11/17/0600Z/2025-11-17T1300.om'
-				)
-			).toThrowError('Model run too far in the past');
 		});
 	});
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -15,9 +15,6 @@ export const OM_PREFIX_REGEX = /^om:\/\/([^?]+)(?:\?(.*))?$/;
 
 export const TILE_SUFFIX_REGEX = /(?:\/)(\d+)(?:\/)(\d+)(?:\/)(\d+)$/i;
 
-export const VALID_OM_URL_REGEX =
-	/(http|https):\/\/(?<uri>[\s\S]+)\/(?<domain>[\s\S]+)\/(?<runYear>[\s\S]+)?\/(?<runMonth>[\s\S]+)?\/(?<runDate>[\s\S]+)?\/(?<runTime>[\s\S]+)?\/(?<file>[\s\S]+)?\.(om|json)(?<params>[\s\S]+)?/;
-
 export const TIME_SELECTED_REGEX = /([0-9]{2}-[0-9]{2}-[0-9]{2}T[0-9]{2}00)/;
 
 /* Variables */

--- a/src/utils/parse-url.ts
+++ b/src/utils/parse-url.ts
@@ -1,13 +1,11 @@
 import { pad } from '.';
-import { domainOptions } from '../domains';
 
 import {
 	DATA_RELEVANT_PARAMS,
 	DOMAIN_META_REGEX,
 	OM_PREFIX_REGEX,
 	TILE_SUFFIX_REGEX,
-	TIME_STEP_REGEX,
-	VALID_OM_URL_REGEX
+	TIME_STEP_REGEX
 } from './constants';
 
 import { DomainMetaDataJson, ParsedUrlComponents, TileIndex } from '../types';
@@ -153,16 +151,4 @@ export const parseMetaJson = async (omUrl: string) => {
 				`${modelRun.getUTCFullYear()}/${pad(modelRun.getUTCMonth() + 1)}/${pad(modelRun.getUTCDate())}/${pad(modelRun.getUTCHours())}00Z/${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())}T${pad(date.getUTCHours())}00.om`
 			)
 	);
-};
-
-export const assertOmUrlValid = (url: string) => {
-	const groups = url.match(VALID_OM_URL_REGEX)?.groups;
-	if (!groups) return false;
-
-	const { domain, runYear } = groups;
-
-	if (!domainOptions.find((d) => d.value == domain)) throw new Error('Invalid Domain');
-	if (Number(runYear) < 2025) throw new Error('Model run too far in the past');
-
-	return true;
 };


### PR DESCRIPTION
This function was of very little use, not properly tested, and would always make a lot of problems with custom domains. IMHO it is better to just get rid of it.