### PR TITLE
feat: Add GraphCast AIGFS and HGEFS

### DIFF
--- a/src/domains.ts
+++ b/src/domains.ts
@@ -210,7 +210,7 @@ export const domainOptions: Array<Domain> = [
 	},
 	{
 		value: 'ncep_hgefs025_ensemble_mean',
-		label: 'GFS HGEFS 0.25°',
+		label: 'GFS HGEFS 0.25° Ensemble Mean',
 		grid: {
 			type: 'regular',
 			nx: 1440,


### PR DESCRIPTION
### Summary

- Added `ncep_gfs_graphcast025` domain option (GFS GraphCast 0.25°)
- Added `ncep_aigfs025` domain option (GFS AIGFS 0.25°)
- Added `ncep_hgefs025_ensemble_mean` domain option (GFS HGEFS 0.25° ensemble mean)

