### PR TITLE
fix: remove separate tile key

### DIFF
--- a/src/om-protocol.ts
+++ b/src/om-protocol.ts
@@ -71,7 +71,7 @@ export const omProtocol = async (
 		throw new Error(`Tile coordinates required for ${params.type} request`);
 	}
 
-	const tile = await requestTile(request, data, state.ranges, params.type);
+	const tile = await requestTile(url, request, data, state.ranges, params.type);
 
 	return { data: tile };
 };
@@ -84,15 +84,8 @@ const normalizeUrl = async (url: string): Promise<string> => {
 	return normalized;
 };
 
-const buildTileKey = (request: ParsedRequest): string => {
-	const { baseUrl, tileIndex } = request;
-	if (!tileIndex) {
-		throw new Error('Cannot build tile key without tile index');
-	}
-	return `${baseUrl}/${tileIndex.z}/${tileIndex.x}/${tileIndex.y}`;
-};
-
 const requestTile = async (
+	url: string,
 	request: ParsedRequest,
 	data: Data,
 	ranges: DimensionRange[],
@@ -102,7 +95,7 @@ const requestTile = async (
 		throw new Error('Tile coordinates required for tile request');
 	}
 
-	const key = buildTileKey(request);
+	const key = `${type}:${url}`;
 	const tileType = `get${capitalize(type)}` as 'getImage' | 'getArrayBuffer';
 
 	// early return if the worker will not return a tile


### PR DESCRIPTION
### Summary

- removes the separate function `buildTileKey`, instead simply the URL is used. 
- this fixes an issue where the `key` was overlapping for multiple variables leading to missing tiles 